### PR TITLE
Support turn_log_datetime off

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 (Unrelease)
 ===================
 
+ - Support not showing_log_datetime by `turn_log_datetime(on=False)`.
+
 0.9.11 (2017-04-07)
 ===================
 

--- a/tests/test_alog.py
+++ b/tests/test_alog.py
@@ -61,6 +61,10 @@ class TestAlog(object):
         alog.set_format("blah")
         alog.turn_process_id(True)
 
+    def test_turn_log_datetime_with_custom_format(self):
+        alog.set_format("blah")
+        alog.turn_log_datetime(True)
+
     def test_not_turn_thread_name(self):
         alog.turn_thread_name(True)
         alog.turn_thread_name(False)


### PR DESCRIPTION
It’s useful for logging in AWS Lambda on AWS CloudWatch.