### PR TITLE
Enforce alog APIs shared by Alogger

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 (Unrelease)
 ===================
 
+ - Support most same APIs between alog and Alogger.
+ - Add ``alog.pdir()`` for handy replacing ``[attr for attr in dir(obj)
+   if not attr.startswith("_")]``.
+
 0.9.13 (2017-06-18)
 ===================
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+from __future__ import \
+    absolute_import, division, print_function, unicode_literals
+
+import sys
+import logging
+
+import alog
+
+
+msg = "msg: Testing alog."
+
+
+class AlogTestBase(object):
+
+    @property
+    def _alog(self):
+        raise NotImplementedError("return a alog thing")
+
+    def setup(self):
+        alog.reset_global_alog()
+        self._alog.set_level("INFO")
+
+    def test_set_level(self):
+        self._alog.set_level("WARNING")
+        assert self._alog.get_level() == logging.WARNING
+
+    def test_set_format(self):
+        orig_format = self._alog.get_format()
+        fs = "Test set format: %(asctime)s %(levelname)-5.5s" \
+            " [%(pathname)s:%(lineno)s] %(message)s"
+        self._alog.set_format(fs)
+        self._alog.set_format(orig_format)
+
+    def test_set_root_name(self):
+        self._alog.set_root_name("alog")
+        self._alog.info(msg)
+
+    def test_critical(self):
+        self._alog.critical(msg)
+
+    def test_fatal(self):
+        self._alog.fatal(msg)
+
+    def test_error(self):
+        self._alog.error(msg)
+
+    def test_exception(self):
+        try:
+            raise Exception(msg)
+        except Exception:
+            exc_info = sys.exc_info()
+            self._alog.exception(msg, exc_info=exc_info)
+
+    def test_warning(self):
+        self._alog.warning(msg)
+
+    def test_warn(self):
+        self._alog.warn(msg)
+
+    def test_turn_thread_name(self):
+        self._alog.turn_process_id(True)
+        self._alog.turn_thread_name(True)
+
+    def test_turn_thread_name_with_custom_format(self):
+        self._alog.set_format("blah")
+        self._alog.turn_thread_name(True)
+
+    def test_turn_process_id_with_custom_format(self):
+        self._alog.set_format("blah")
+        self._alog.turn_process_id(True)
+
+    def test_turn_log_datetime_with_custom_format(self):
+        self._alog.set_format("blah")
+        self._alog.turn_log_datetime(True)
+
+    def test_not_turn_thread_name(self):
+        self._alog.turn_thread_name(True)
+        self._alog.turn_thread_name(False)
+
+    def test_not_turn_process_id(self):
+        self._alog.turn_process_id(True)
+        self._alog.turn_process_id(False)
+
+    def test_not_turn_process_id_and_turn_thread_name(self):
+        self._alog.turn_thread_name(True)
+        self._alog.turn_process_id(True)
+        self._alog.turn_process_id(False)
+
+    def test_turn_process_id_and_not_turn_thread_name(self):
+        self._alog.turn_thread_name(True)
+        self._alog.turn_process_id(True)
+        self._alog.turn_thread_name(False)
+
+    def test_info(self):
+        self._alog.info(msg)
+
+    def test_debug(self):
+        self._alog.debug(msg)
+
+    def test_log(self):
+        level = logging.INFO
+        self._alog.log(level, msg)
+
+    def test_extra(self):
+        self._alog.info(msg, extra={'Memo': "Extra testing."})
+
+    def test_keyerror_in_extra(self):
+        try:
+            self._alog.info(msg, extra={'message': "Extra testing."})
+        except KeyError:
+            pass
+
+    def test_pformat(self):
+        msg = {'life is strange': True,
+               'list is weird': list(range(10))}
+        self._alog.info(alog.pformat(msg))
+
+    def test_pdir(self):
+        class Thing(object):
+            pass
+        thing = Thing()
+        thing._private_thing = True
+        thing.public_thing = True
+        assert "public_thing" in str(self._alog.pdir(thing))
+        assert "_private_thing" not in str(self._alog.pdir(thing))

--- a/tests/test_alog.py
+++ b/tests/test_alog.py
@@ -1,123 +1,19 @@
-import sys
-import logging
+# -*- coding: utf-8 -*-
+from __future__ import \
+    absolute_import, division, print_function, unicode_literals
 
 import alog
 
+from .base import AlogTestBase
 
 msg = "msg: Testing alog."
 
 
-class TestAlog(object):
+class TestAlog(AlogTestBase):
 
-    def setup(self):
-        alog.reset()
-
-    def test_set_level(self):
-        alog.set_level("WARNING")
-        assert alog.get_level() == logging.WARNING
-
-    def test_set_format(self):
-        orig_format = alog.get_format()
-        fs = "Test set format: %(asctime)s %(levelname)-5.5s" \
-            " [%(pathname)s:%(lineno)s] %(message)s"
-        alog.set_format(fs)
-        alog.set_format(orig_format)
-
-    def test_set_root_name(self):
-        alog.set_root_name("alog")
-        alog.info(msg)
-
-    def test_critical(self):
-        alog.critical(msg)
-
-    def test_fatal(self):
-        alog.fatal(msg)
-
-    def test_error(self):
-        alog.error(msg)
-
-    def test_exception(self):
-        try:
-            raise Exception(msg)
-        except Exception:
-            exc_info = sys.exc_info()
-            alog.exception(msg, exc_info=exc_info)
-
-    def test_warning(self):
-        alog.warning(msg)
-
-    def test_warn(self):
-        alog.warn(msg)
-
-    def test_turn_thread_name(self):
-        alog.turn_process_id(True)
-        alog.turn_thread_name(True)
-
-    def test_turn_thread_name_with_custom_format(self):
-        alog.set_format("blah")
-        alog.turn_thread_name(True)
-
-    def test_turn_process_id_with_custom_format(self):
-        alog.set_format("blah")
-        alog.turn_process_id(True)
-
-    def test_turn_log_datetime_with_custom_format(self):
-        alog.set_format("blah")
-        alog.turn_log_datetime(True)
-
-    def test_not_turn_thread_name(self):
-        alog.turn_thread_name(True)
-        alog.turn_thread_name(False)
-
-    def test_not_turn_process_id(self):
-        alog.turn_process_id(True)
-        alog.turn_process_id(False)
-
-    def test_not_turn_process_id_and_turn_thread_name(self):
-        alog.turn_thread_name(True)
-        alog.turn_process_id(True)
-        alog.turn_process_id(False)
-
-    def test_turn_process_id_and_not_turn_thread_name(self):
-        alog.turn_thread_name(True)
-        alog.turn_process_id(True)
-        alog.turn_thread_name(False)
-
-    def test_info(self):
-        alog.info(msg)
-
-    def test_debug(self):
-        alog.debug(msg)
-
-    def test_log(self):
-        level = logging.INFO
-        alog.log(level, msg)
-
-    def test_extra(self):
-        alog.info(msg, extra={'Memo': "Extra testing."})
-
-    def test_keyerror_in_extra(self):
-        try:
-            alog.info(msg, extra={'message': "Extra testing."})
-        except KeyError:
-            pass
-
-    def test_pformat(self):
-        msg = {'life is strange': True,
-               'list is weird': list(range(10))}
-        alog.info(alog.pformat(msg))
-
-    def test_pdir(self):
-        class Thing(object):
-            pass
-        thing = Thing()
-        thing._private_thing = True
-        thing.public_thing = True
-        assert "public_thing" in str(alog.pdir(thing))
-        assert "_private_thing" not in str(alog.pdir(thing))
-
-    def test_disable(self):
-        alog.disable("INFO")
+    @property
+    def _alog(self):
+        return alog
 
     def test_getLogger_with_argument(self):
         logger = alog.getLogger("whatever_argument")
@@ -128,3 +24,6 @@ class TestAlog(object):
     def test_getLogger_without_name_given(self):
         logger = alog.getLogger()
         assert logger == alog.default_logger
+
+    def test_disable_level(self):
+        self._alog.disable("INFO")

--- a/tests/test_alogger.py
+++ b/tests/test_alogger.py
@@ -1,0 +1,15 @@
+from __future__ import \
+    absolute_import, division, print_function, unicode_literals
+
+import alog
+
+from .base import AlogTestBase
+
+msg = "msg: Testing alog."
+
+
+class TestAlog(AlogTestBase):
+
+    @property
+    def _alog(self):
+        return alog.default_logger


### PR DESCRIPTION
Then it's eaiser to switch `logger = alog` to `logger = alog.default_logger` (or old school style `logger = alog.getLogger()`).