### PR TITLE
Support Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
         - python: 3.6
           env: TOXENV=py36
         - python: 3.7
-          sudo: required
-          dist: xenial
           env: TOXENV=py37
+        - python: 3.8
+          env: TOXENV=py38
         - python: pypy
           env: TOXENV=pypy
-        - python: 3.6
+        - python: 3.8
           env: TOXENV=py2-cover,py3-cover,coverage
 
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 (Unrelease)
 ===================
 
+1.1.0 (2020-02-10)
+==================
+
+ - Support Python 3.8
+ - Fix broken ``set_format`` function when formatter argument is given.
+
 1.0.0 (2019-04-03)
 ==================
 

--- a/alog/__init__.py
+++ b/alog/__init__.py
@@ -71,12 +71,12 @@ def reset_global_alog():
 
 
 def init_alogger(alog_config, default_root_name=None):
-    logger = Alogger(default_root_name)
-    logger.alog_config = alog_config
+    alogger = Alogger(default_root_name)
+    alogger.alog_config = alog_config
     sh = StreamHandler()
-    logger.addHandler(sh)
-    set_format(logger.alog_config['default_format'], logger, is_default=True)
-    return logger
+    alogger.addHandler(sh)
+    set_format(alogger.alog_config['default_format'], alogger, is_default=True)
+    return alogger
 
 
 def getLogger(*args, **kwargs):
@@ -116,17 +116,25 @@ def get_level(alogger=None):
     return alogger.get_level()
 
 
+def set_formatter(formatter, alogger=None):
+    alogger = alogger or default_logger
+    alogger.set_formatter(formatter)
+
+
 def set_format(fs, alogger=None, is_default=False,
                time_strfmt="%Y-%m-%d %H:%M:%S"):
     alogger = alogger or default_logger
     alogger.set_format(fs, is_default=is_default, time_strfmt=time_strfmt)
 
 
-def get_format(logger=None):
-    logger = logger or default_logger
-    for handler in logger.handlers:
-        if handler.formatter:
-            return handler.formatter
+def get_formatter(alogger=None):
+    alogger = alogger or default_logger
+    return alogger.get_formatter()
+
+
+def get_format(alogger=None):
+    alogger = alogger or default_logger
+    return alogger.get_format()
 
 
 def set_root_name(root_name, alogger=None):

--- a/alog/alogger.py
+++ b/alog/alogger.py
@@ -143,10 +143,23 @@ class Alogger(Logger):
                 return handler.level
 
     def get_format(self, logger=None):
-        logger = logger or self
-        for handler in self.handlers:
+        from warnings import warn
+        msg = "`get_format()` actually return a Formatter. " \
+            "Use `get_formatter()` instead."
+        warn(msg)
+        alogger = logger or self
+        return alogger.get_formatter()
+
+    def get_formatter(self, logger=None):
+        alogger = logger or self
+        for handler in alogger.handlers:
             if handler.formatter:
                 return handler.formatter
+
+    def set_formatter(self, formatter, alogger=None):
+        alogger = alogger or self
+        for handler in alogger.handlers:
+            handler.setFormatter(formatter)
 
     def set_format(self, fs, alogger=None, is_default=False,
                    time_strfmt="%Y-%m-%d %H:%M:%S"):
@@ -154,8 +167,7 @@ class Alogger(Logger):
         formatter = Formatter(fs, time_strfmt) \
             if in_python2_runtime \
             else Formatter(fs, time_strfmt, "%")
-        for handler in alogger.handlers:
-            handler.setFormatter(formatter)
+        alogger.set_formatter(formatter, alogger=alogger)
         if not is_default:
             alogger.alog_config['custom_format'] = fs
 

--- a/alog/alogger.py
+++ b/alog/alogger.py
@@ -24,7 +24,7 @@ class Alogger(Logger):
     def _alog_fn(self, fn):
         if 'ipython-input-' in fn:  # pragma: no cover
             return "<IPython"
-        elif fn == '<stdin>':  # pragma: no cover
+        if fn == '<stdin>':  # pragma: no cover
             return '<stdin'
 
         paths = []

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ docs_extras = [
 
 setup(
     name='alog',
-    version='1.0.0',
+    version='1.1.0',
     description='Your goto Python logging without panic on context swtich',
     long_description=README + '\n\n' + CHANGES,
     url='https://github.com/keitheis/alog',
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,12 +25,18 @@ class AlogTestBase(object):
         self._alog.set_level("WARNING")
         assert self._alog.get_level() == logging.WARNING
 
+    def test_get_formatter(self):
+        orig_formatter = self._alog.get_formatter()
+        assert orig_formatter
+        self._alog.set_formatter(orig_formatter)
+
     def test_set_format(self):
-        orig_format = self._alog.get_format()
+        orig_formatter = self._alog.get_format()
+        assert orig_formatter
         fs = "Test set format: %(asctime)s %(levelname)-5.5s" \
             " [%(pathname)s:%(lineno)s] %(message)s"
         self._alog.set_format(fs)
-        self._alog.set_format(orig_format)
+        self._alog.set_formatter(orig_formatter)
 
     def test_set_root_name(self):
         self._alog.set_root_name("alog")
@@ -63,15 +69,15 @@ class AlogTestBase(object):
         self._alog.turn_logging_thread_name(True)
 
     def test_turn_logging_thread_name_with_custom_format(self):
-        self._alog.set_format("blah")
+        self._alog.set_format("blah %(test)s")
         self._alog.turn_logging_thread_name(True)
 
     def test_turn_logging_process_id_with_custom_format(self):
-        self._alog.set_format("blah")
+        self._alog.set_format("blah %(test)s")
         self._alog.turn_logging_process_id(True)
 
     def test_turn_logging_datetime_with_custom_format(self):
-        self._alog.set_format("blah")
+        self._alog.set_format("blah %(test)s")
         self._alog.turn_logging_datetime(True)
 
     def test_not_turn_thread_name(self):

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,10 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy: pypy
     py2: python2.7
-    py3: python3.6
+    py3: python3.8
 
 passenv = TOXENV CI TRAVIS TRAVIS_*
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ setenv =
     COVERAGE_FILE=.coverage.py3
 
 [testenv:coverage]
-basepython = python3.6
+basepython = python3.8
 commands =
     coverage erase
     coverage combine


### PR DESCRIPTION
## Changes

- Fixed `get_formatter` usage in Python 3.8.
- Fixed `alog.get_format` not using `alogger.get_format()`.
- Fix failed test by replaced with "blah %(test)s" string.